### PR TITLE
Add options 'logrotate_user' and 'logrotate_group'

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ logrotate_keep: 4
 
 # Should rotated logs be compressed??
 logrotate_compress: yes
+
+# User/Group for rotated log files
+logrotate_user: root
+logrotate_group: syslog
 ```
 
 ## [Requirements](#requirements)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,7 @@ logrotate_keep: 4
 
 # Should rotated logs be compressed??
 logrotate_compress: yes
+
+# User/Group for rotated log files
+logrotate_user: root
+logrotate_group: syslog

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,6 +8,8 @@
     logrotate_frequency: daily
     logrotate_keep: 7
     logrotate_compress: yes
+    logrotate_user: root
+    logrotate_group: syslog
     logrotate_entries:
       - name: example
         path: "/var/log/example/*.log"

--- a/templates/logrotate.conf.j2
+++ b/templates/logrotate.conf.j2
@@ -6,7 +6,7 @@
 
 # use the syslog group by default, since this is the owning group
 # of /var/log/syslog.
-su root syslog
+su {{ logrotate_user }} {{ logrotate_group }}
 
 # keep 4 weeks worth of backlogs
 rotate {{ logrotate_keep }}


### PR DESCRIPTION
---
name: Pull request
about: Add the options `logrotate_user` and `logrotate_group` to customize the user/group used for rotating the log files.

---

**Describe the change**

The role uses hardcoded values for user/group `root` and `syslog`. I ran into an issue, where I do not have `rsyslog` installed and no group named `syslog` in the system. Therefore I created this PR to customize the user/group used for rotating the log files.

