### PR TITLE
Add sharedscripts option

### DIFF
--- a/templates/entry.j2
+++ b/templates/entry.j2
@@ -16,6 +16,8 @@
 
 {% if item.create is defined and item.create %}    create{% if item.create_mode is defined %} {{ item.create_mode }}{% endif %}{% if item.create_user is defined %} {{ item.create_user }}{% endif %}{% if item.create_group is defined %} {{ item.create_group }}{% endif %}{% endif %}
 
+{% if item.sharedscripts is defined and item.sharedscripts %}    sharedscripts{% endif %}
+
 {% if item.postrotate is defined %}    postrotate
         {{ item.postrotate }}
     endscript{% endif %}


### PR DESCRIPTION
---
name: Pull request
about: Add sharedscripts option

---

**Describe the change**
Allow to pass sharedscripts option.
The sharedscripts means that the postrotate script will only be run once (after the old logs have been compressed), not once for each log which is rotated. Note that the double quotes around the first filename at the beginning of this section allows logrotate to rotate logs with spaces in the name.

**Testing**
In case a feature was added, how were tests performed?

Tested manually.
