### PR TITLE
Add dateext and nomissingok options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@ logrotate_keep: 4
 # Should rotated logs be compressed??
 logrotate_compress: yes
 
+# Use date extension on log file names
+logrotate_dateext: no
+
 # User/Group for rotated log files (Loaded by OS-Specific vars if found, or and can be set manually)
 logrotate_user: "{{ _logrotate_user[ansible_distribution] | default(_logrotate_user['default'] ) }}"
 logrotate_group: "{{ _logrotate_group[ansible_distribution] | default(_logrotate_group['default'] ) }}"

--- a/templates/entry.j2
+++ b/templates/entry.j2
@@ -12,6 +12,8 @@
 
 {% if item.missingok is defined and item.missingok %}    missingok{% endif %}
 
+{% if item.nomissingok is defined and item.nomissingok %}    nomissingok{% endif %}
+
 {% if item.notifempty is defined and item.notifempty %}    notifempty{% endif %}
 
 {% if item.create is defined and item.create %}    create{% if item.create_mode is defined %} {{ item.create_mode }}{% endif %}{% if item.create_user is defined %} {{ item.create_user }}{% endif %}{% if item.create_group is defined %} {{ item.create_group }}{% endif %}{% endif %}

--- a/templates/logrotate.conf.j2
+++ b/templates/logrotate.conf.j2
@@ -14,6 +14,13 @@ rotate {{ logrotate_keep }}
 # create new (empty) log files after rotating old ones
 create
 
+# add dateext
+{% if logrotate_dateext %}
+dateext
+{% else %}
+#dateext
+{% endif %}
+
 # uncomment this if you want your log files compressed
 {% if logrotate_compress %}
 compress


### PR DESCRIPTION
---
name: Add dateext and nomissingok options
about: Add dateext and nomissingok options which might be useful for logrotate config files

---

G'day

I'm using this role and have added the `dateext` option to logrotate.conf and `nomissingok` option to the logrotate.d files.

These are fairly minor changes but might be useful for users of the role.

Cheers
Andrew