### PR TITLE
Add `dateext` and `dateformat` to entries

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -31,6 +31,8 @@
         create_mode: "0660"
         create_user: root
         create_group: utmp
+        dateext: yes
+        dateformat: "-%Y-%m-%d"
         keep: 1
       - name: wtmp
         path: /var/log/wtmp
@@ -41,6 +43,8 @@
         create_user: root
         create_group: utmp
         minsize: 1M
+        dateext: yes
+        dateformat: "-%Y%m%d"
         keep: 1
       - name: dnf
         path: /var/log/hawkey.log

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -184,3 +184,25 @@
     label: "{{ item.name }}"
   when:
     - item.sharedscripts is defined
+
+- name: test if dateext in logrotate_entries is set correctly
+  ansible.builtin.assert:
+    that:
+      - item.dateext is boolean
+    quiet: yes
+  loop: "{{ logrotate_entries }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - item.dateext is defined
+
+- name: test if dateformat in logrotate_entries is set correctly
+  ansible.builtin.assert:
+    that:
+      - item.dateformat is string
+    quiet: yes
+  loop: "{{ logrotate_entries }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - item.dateformat is defined

--- a/templates/entry.j2
+++ b/templates/entry.j2
@@ -20,6 +20,10 @@
 
 {% if item.sharedscripts is defined and item.sharedscripts %}    sharedscripts{% endif %}
 
+{% if item.dateext is defined and item.dateext %}    dateext{% endif %}
+
+{% if item.dateformat is defined and item.dateformat %}    dateformat {{ item.dateformat }}{% endif %}
+
 {% if item.postrotate is defined %}    postrotate
         {{ item.postrotate }}
     endscript{% endif %}


### PR DESCRIPTION
---
name: Add `dateext` and `dateformat` to entries
about: Add `dateext` and `dateformat` config to logrotate entries 

---

This PR add configuration for `dateext` and `dateformat` in the logrotate entries. It should close issue #6 
