### PR TITLE
feat: add ability for multiple entry paths and postrotate commands

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -61,7 +61,10 @@
       - item.name is string
       - item.name is not none
       - item.path is defined
-      - item.path is string
+      - item.path is string or
+        (item.path is iterable and
+        item.path is not string and
+        item.path is not mapping)
       - item.path is not none
     quiet: yes
   loop: "{{ logrotate_entries }}"
@@ -119,7 +122,10 @@
 - name: assert | Test if postrotate in logrotate_entries is set correctly
   ansible.builtin.assert:
     that:
-      - item.postrotate is string
+      - item.postrotate is string or
+        (item.postrotate is iterable and
+        item.postrotate is not string and
+        item.postrotate is not mapping)
       - item.postrotate is not none
     quiet: yes
   loop: "{{ logrotate_entries }}"

--- a/templates/entry.j2
+++ b/templates/entry.j2
@@ -1,6 +1,12 @@
 {{ ansible_managed | comment }}
 
+{% if item.path is iterable and item.path is not string and item.path is not mapping %}
+{% for path in item.path %}
+{{ path }}{{ " {" if loop.last }}
+{% endfor %}
+{% else %}
 {{ item.path }} {
+{% endif %}
 {% if item.frequency is defined %}
     {{ item.frequency }}
 {% endif %}
@@ -37,7 +43,13 @@
 {% endif %}
 {% if item.postrotate is defined %}
     postrotate
+{% if item.postrotate is iterable and item.postrotate is not string and item.postrotate is not mapping %}
+{% for cmd in item.postrotate %}
+        {{ cmd }}
+{% endfor %}
+{% else %}
         {{ item.postrotate }}
+{% endif %}
     endscript
 {% endif %}
 }

--- a/templates/entry.j2
+++ b/templates/entry.j2
@@ -1,39 +1,43 @@
 {{ ansible_managed | comment }}
 
 {{ item.path }} {
+{% if item.frequency is defined %}
+    {{ item.frequency }}
+{% endif %}
+{% if item.compress is defined and item.compress %}
+    compress
+{% endif %}
+{% if item.delaycompress is defined and item.delaycompress %}
+    delaycompress
+{% endif %}
+{% if item.keep is defined %}
+    rotate {{ item.keep }}
+{% endif %}
+{% if item.minsize is defined %}
+    minsize {{ item.minsize }}
+{% endif %}
+{% if item.missingok is defined and item.missingok %}
+    missingok
+{% endif %}
+{% if item.nomissingok is defined and item.nomissingok %}
+    nomissingok
+{% endif %}
+{% if item.notifempty is defined and item.notifempty %}
+    notifempty
+{% endif %}
+{% if item.create is defined and item.create %}
+    create{# #}
+{% if item.create_mode is defined %} {{ item.create_mode }}{% endif %}
+{% if item.create_user is defined %} {{ item.create_user }}{% endif %}
+{% if item.create_group is defined %} {{ item.create_group }}{% endif %}
 
-{% if item.frequency is defined %}    {{ item.frequency }}{% endif %}
-
-{% if item.compress is defined and item.compress %}    compress{% endif %}
-
-{% if item.delaycompress is defined and item.delaycompress %}    delaycompress{% endif %}
-
-{% if item.keep is defined %}    rotate {{ item.keep }}{% endif %}
-
-{% if item.minsize is defined %}    minsize {{ item.minsize }}{% endif %}
-
-{% if item.missingok is defined and item.missingok %}    missingok{% endif %}
-
-{% if item.nomissingok is defined and item.nomissingok %}    nomissingok{% endif %}
-
-{% if item.notifempty is defined and item.notifempty %}    notifempty{% endif %}
-
-{% if item.copylog is defined and item.copylog %}    copy{% endif %}
-
-{% if item.copytruncate is defined and item.copytruncate %}    copytruncate{% endif %}
-
-{% if item.create is defined and item.create %}    create{% if item.create_mode is defined %} {{ item.create_mode }}{% endif %}{% if item.create_user is defined %} {{ item.create_user }}{% endif %}{% if item.create_group is defined %} {{ item.create_group }}{% endif %}{% endif %}
-
-{% if item.sharedscripts is defined and item.sharedscripts %}    sharedscripts{% endif %}
-
-{% if item.dateext is defined and item.dateext %}    dateext{% endif %}
-
-{% if item.dateformat is defined and item.dateformat %}    dateformat {{ item.dateformat }}{% endif %}
-
-{% if item.dateyesterday is defined and item.dateyesterday %}    dateyesterday{% endif %}
-
-{% if item.postrotate is defined %}    postrotate
+{% endif %}
+{% if item.sharedscripts is defined and item.sharedscripts %}
+    sharedscripts
+{% endif %}
+{% if item.postrotate is defined %}
+    postrotate
         {{ item.postrotate }}
-    endscript{% endif %}
-
+    endscript
+{% endif %}
 }


### PR DESCRIPTION
Hi,

this branch is based on #8 which fixes the unnecessary blank lines the current template produces.

**Describe the change**
This branch also adds the ability to specify a list for the `path` and `postrotate` variable, as having multiple paths and postrotate-commands is perfectly fine in logrotate.
It is however still possible to simply specify a single string as before (just to not break existing setups) - necessary checks where added in `assert.yml` (Fixes #15)

**Testing**
I checked the result produced by the template and it looked fine, both for multiple and single paths/postrotate commands.