### PR TITLE
Add support for prerotate script (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ This example is taken from [`molecule/default/converge.yml`](https://github.com/
       - name: example-delaycompress
         path: "/var/log/example-delaycompress/*.log"
         delaycompress: true
-      - name: example-script
-        path: "/var/log/example-script/*.log"
+      - name: example-prerotate-script
+        path: "/var/log/example-prerotate-script/*.log"
+        prerotate: echo "e.g. backup to an offsite location"
+      - name: example-postrotate-script
+        path: "/var/log/example-postrotate-script/*.log"
         postrotate: killall -HUP some_process_name
       - name: btmp
         path: /var/log/btmp

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -29,8 +29,11 @@
       - name: example-delaycompress
         path: "/var/log/example-delaycompress/*.log"
         delaycompress: true
-      - name: example-script
-        path: "/var/log/example-script/*.log"
+      - name: example-prerotate-script
+        path: "/var/log/example-prerotate-script/*.log"
+        prerotate: echo "e.g. backup to an offsite location"
+      - name: example-postrotate-script
+        path: "/var/log/example-postrotate-script/*.log"
         postrotate: killall -HUP some_process_name
       - name: btmp
         path: /var/log/btmp

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -22,7 +22,8 @@
         - /var/log/example-copylog
         - /var/log/example-copytruncate
         - /var/log/example-delaycompress
-        - /var/log/example-script
+        - /var/log/example-prerotate-script
+        - /var/log/example-postrotate-script
         - /var/log/example-sharedscripts
         - /var/log/example-dateyesterday
 
@@ -39,7 +40,8 @@
         - /var/log/example-copylog/app.log
         - /var/log/example-copytruncate/app.log
         - /var/log/example-delaycompress/app.log
-        - /var/log/example-script/app.log
+        - /var/log/example-prerotate-script/app.log
+        - /var/log/example-postrotate-script/app.log
         - /var/log/example-sharedscripts/app.log
         - /var/log/example-dateyesterday/app.log
         - /var/log/btmp

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -127,6 +127,18 @@
   when:
     - item.delaycompress is defined
 
+- name: assert | Test prerotate in logrotate_entries
+  ansible.builtin.assert:
+    that:
+      - item.prerotate is string
+      - item.prerotate is not none
+    quiet: true
+  loop: "{{ logrotate_entries }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - item.prerotate is defined
+
 - name: assert | Test postrotate in logrotate_entries
   ansible.builtin.assert:
     that:

--- a/templates/entry.j2
+++ b/templates/entry.j2
@@ -34,6 +34,10 @@
 
 {% if item.dateyesterday is defined and item.dateyesterday %}    dateyesterday{% endif %}
 
+{% if item.prerotate is defined %}    prerotate
+        {{ item.prerotate }}
+    endscript{% endif %}
+
 {% if item.postrotate is defined %}    postrotate
         {{ item.postrotate }}
     endscript{% endif %}


### PR DESCRIPTION
---
name: Add prerotate
about: logrotate allows for a user to specify a script that can be run before the rotate process runs. This change adds that functionality to this role.

---

**Describe the change**
I've copied the postrotate feature, and its tests, and duplicated it as prerotate.

**Testing**
Unfortunately, despite my efforts, I haven't been able to get molecule running with docker locally, and so I haven't been able to run the tests. It seems that docker-py 2.32.0 / requests has a an issue with ansible 9.6. I've tried upgrading to ansible 10.0.0b1, but I still haven't been able to get it to work.