### PR TITLE
Adds support for multiple entry paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This example is taken from [`molecule/default/converge.yml`](https://github.com/
       - name: example-script
         path: "/var/log/example-script/*.log"
         postrotate: killall -HUP some_process_name
+      - name: example-multipath
+        path:
+          - "/var/log/example-multipath-one/*.log"
+          - "/var/log/example-multipath-two/*.log"
       - name: btmp
         path: /var/log/btmp
         missingok: true

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -32,6 +32,10 @@
       - name: example-script
         path: "/var/log/example-script/*.log"
         postrotate: killall -HUP some_process_name
+      - name: example-multipath
+        path:
+          - "/var/log/example-multipath-one/*.log"
+          - "/var/log/example-multipath-two/*.log"
       - name: btmp
         path: /var/log/btmp
         missingok: true

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -25,6 +25,8 @@
         - /var/log/example-script
         - /var/log/example-sharedscripts
         - /var/log/example-dateyesterday
+        - /var/log/example-multipath-one
+        - /var/log/example-multipath-two
 
     - name: Create log file
       ansible.builtin.copy:
@@ -42,6 +44,8 @@
         - /var/log/example-script/app.log
         - /var/log/example-sharedscripts/app.log
         - /var/log/example-dateyesterday/app.log
+        - /var/log/example-multipath-one/app.log
+        - /var/log/example-multipath-two/app.log
         - /var/log/btmp
         - /var/log/wtmp
         - /var/log/hawkey.log

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -59,7 +59,10 @@
       - item.name is string
       - item.name is not none
       - item.path is defined
-      - item.path is string
+      - item.path is string or
+        (item.path is iterable and
+        item.path is not string and
+        item.path is not mapping)
       - item.path is not none
     quiet: true
   loop: "{{ logrotate_entries }}"

--- a/templates/entry.j2
+++ b/templates/entry.j2
@@ -1,7 +1,12 @@
 {{ ansible_managed | comment }}
 
+{% if item.path is iterable and item.path is not string and item.path is not mapping %}
+{% for path in item.path %}
+{{ path }}{{ " {" if loop.last }}
+{% endfor %}
+{% else %}
 {{ item.path }} {
-
+{% endif %}
 {% if item.frequency is defined %}    {{ item.frequency }}{% endif %}
 
 {% if item.compress is defined and item.compress %}    compress{% endif %}


### PR DESCRIPTION
---
name: Support use of multiple paths in logrotate configuration.
about: The logroate configuration specification allows for multiple paths to be specified. This change enables that capability within this role.

---

**Describe the change**
In #16, @tazend adds this functionality, as well as the ability to handle multiple postrotate commands. I needed the ability to support multiple paths, but as yet I don't have the requirement to use multiple postrotate scripts. And so I thought I'd take what I needed from @tazend's change, and add it in a single PR, so that I could isolate that change from the postrotate stuff, thus making it easier for me to manage. Allows either an individual path, or multiple paths to be affected by the logrotate configuration specified.

**Testing**
I've added test cases for this, and been able to run verify against them:

```
molecule verify
WARNING  Driver docker does not provide a schema.
INFO     default scenario test matrix: verify
INFO     Performing prerun with role_name_check=0...
INFO     Running default > verify
INFO     Running Ansible Verifier
INFO     Sanity checks: 'docker'

PLAY [Verify] ******************************************************************

TASK [Run logrotate] ***********************************************************
changed: [logrotate-fedora-latest]

PLAY RECAP *********************************************************************
logrotate-fedora-latest    : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

INFO     Verifier completed successfully.
```