### PR TITLE
Nocompress

### DIFF
--- a/templates/entry.j2
+++ b/templates/entry.j2
@@ -4,7 +4,8 @@
 
 {% if item.frequency is defined %}    {{ item.frequency }}{% endif %}
 
-{% if item.compress is defined and item.compress %}    compress{% endif %}
+{% if item.compress is defined and item.compress %}    compress
+{% elif item.compress is defined and not item.compress %}    nocompress{% endif %}
 
 {% if item.delaycompress is defined and item.delaycompress %}    delaycompress{% endif %}
 


### PR DESCRIPTION
---
name: Allow disabling compression for certain files
about: The role default is to compress or disable compression altogether but currently does not support disabling compression for a single entry.

---

**Describe the change**
If a user specifies `compress: no` for a given entry, the result should be to render `nocompress` in the configuration file as otherwise the main default will apply. 
This is a bit of a particular edge case maybe, but I need it for a central log server where the logs coming from remote nodes are stored on ZFS that has filesystem level compression enabled so I don't need compression on this particular entry (the remote logs being forwarded) but I still need the default compression settings for the system logs.

**Testing**
None
