### PR TITLE
add hourly logrotate_frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The default values for the variables are set in [`defaults/main.yml`](https://gi
 ---
 # defaults file for logrotate
 
-# How often to rotate logs, either daily, weekly or monthly.
+# How often to rotate logs, either hourly, daily, weekly or monthly.
 logrotate_frequency: weekly
 
 # How many files to keep.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for logrotate
 
-# How often to rotate logs, either daily, weekly or monthly.
+# How often to rotate logs, either hourly, daily, weekly or monthly.
 logrotate_frequency: weekly
 
 # How many files to keep.

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -9,7 +9,7 @@ argument_specs:
     options:
       logrotate_frequency:
         type: str
-        description: "How often to rotate logs, either daily, weekly or monthly."
+        description: "How often to rotate logs, either hourly, daily, weekly or monthly."
         default: "weekly"
       logrotate_keep:
         type: int

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -5,7 +5,7 @@
     that:
       - logrotate_frequency is defined
       - logrotate_frequency is string
-      - logrotate_frequency in [ "daily", "weekly", "monthly" ]
+      - logrotate_frequency in [ "hourly", "daily", "weekly", "monthly" ]
     quiet: true
 
 - name: assert | Test logrotate_keep
@@ -85,7 +85,7 @@
   ansible.builtin.assert:
     that:
       - item.frequency is string
-      - item.frequency in [ "daily", "weekly", "monthly" ]
+      - item.frequency in [ "hourly", "daily", "weekly", "monthly" ]
     quiet: true
   loop: "{{ logrotate_entries }}"
   loop_control:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,3 +49,21 @@
     enabled: "{{ logrotate_service_enabled }}"
   when:
     - logrotate_service != ""
+
+- name: Enable hourly logrotate
+  community.general.ini_file:
+    dest: "/etc/systemd/system/{{ logrotate_service }}.d/override.conf"
+    section: Timer
+    option: OnCalendar
+    value: "hourly"
+  when:
+    - logrotate_service != ""
+    - logrotate_frequency == "hourly"
+
+- name: Disable hourly logrotate
+  ansible.builtin.file:
+    path: "/etc/systemd/system/{{ logrotate_service }}.d/override.conf"
+    state: absent
+  when:
+    - logrotate_service != ""
+    - logrotate_frequency != "hourly"


### PR DESCRIPTION
---
name: Pull request
about: add hourly logrotate_frequency

---

**Describe the change**
add hourly logrotate_frequency

**Testing**
In case a feature was added, how were tests performed?

- Apply change on Ubuntu 20.04.6 LTS with :

```yaml
logrotate_frequency: hourly
logrotate_entries:
  - name: rsyslog
    path: |-
      /var/log/messages
      /var/log/secure
      /var/log/maillog
      /var/log/cron
      /var/log/boot.log
      /var/log/auth.log
      /var/log/syslog
    postrotate: /usr/lib/rsyslog/rsyslog-rotate
    missingok: yes
    frequency: hourly
    minsize: 1M
    maxsize: 10M
    keep: 7
```

- Check logrotate.timer status

```
● logrotate.timer - Daily rotation of log files
     Loaded: loaded (/lib/systemd/system/logrotate.timer; enabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/logrotate.timer.d
             └─override.conf
     Active: active (waiting) since Tue 2024-10-29 09:49:19 UTC; 2 months 2 days ago
    Trigger: Tue 2024-12-31 12:00:00 UTC; 45min left
   Triggers: ● logrotate.service
       Docs: man:logrotate(8)
             man:logrotate.conf(5)
```
